### PR TITLE
Update _widget.htm to refresh 

### DIFF
--- a/reportwidgets/embeddedwidget/partials/_widget.htm
+++ b/reportwidgets/embeddedwidget/partials/_widget.htm
@@ -14,6 +14,7 @@
             frameborder="0"
             marginheight="0"
             marginwidth="0"
+            onload="iFrameResize()"
         ></iframe>
     <?php else: ?>
         <div class="callout callout-warning">


### PR DESCRIPTION
In certain situations, the iFrame is not refreshed. This has been described in https://github.com/davidjbradshaw/iframe-resizer/issues/443 and can be fixed by adding a simple onload command.